### PR TITLE
Revert "Modifies fmc pin names generation for afc3v1" - updated fmc pins in migen repository

### DIFF
--- a/artiq/gateware/fmc.py
+++ b/artiq/gateware/fmc.py
@@ -1,18 +1,15 @@
-def _fmc_pin(fmc: str, bank: str, i: int, pol: str, k: bool):
+def _fmc_pin(fmc: str, bank: str, i: int, pol: str):
     bank = bank.upper()
     pol = pol.upper()
     cc_pin_name_tmp = "fmc{fmc}:{bank}{i:02d}_CC_{pol}"
     pin_name_tmp = "fmc{fmc}:{bank}{i:02d}_{pol}"
-    if k:
-        cc_pins = {
-            "LA": [0, 1, 17, 18],
-            "HA": [0, 1, 17],
-            "HB": [0, 6, 17],
-        }
-        if i in cc_pins[bank]:
-            return cc_pin_name_tmp.format(fmc=fmc, bank=bank, i=i, pol=pol)
-        else:
-            return pin_name_tmp.format(fmc=fmc, bank=bank, i=i, pol=pol)
+    cc_pins = {
+        "LA": [0, 1, 17, 18],
+        "HA": [0, 1, 17],
+        "HB": [0, 6, 17],
+    }
+    if i in cc_pins[bank]:
+        return cc_pin_name_tmp.format(fmc=fmc, bank=bank, i=i, pol=pol)
     else:
         return pin_name_tmp.format(fmc=fmc, bank=bank, i=i, pol=pol)
 


### PR DESCRIPTION
This reverts commit 0a06e538f07b97ee8605631df4df83bda8ab6699. Updated fmc pins in migen repository