### PR TITLE
Add explanation mark on tab title when there is new interactive argum…

### DIFF
--- a/artiq/dashboard/interactive_args.py
+++ b/artiq/dashboard/interactive_args.py
@@ -73,6 +73,7 @@ class _InteractiveArgsRequest(EntryTreeWidget):
 class _InteractiveArgsView(QtWidgets.QStackedWidget):
     supplied = QtCore.pyqtSignal(int, dict)
     cancelled = QtCore.pyqtSignal(int)
+    alert = QtCore.pyqtSignal()
 
     def __init__(self):
         QtWidgets.QStackedWidget.__init__(self)
@@ -111,6 +112,7 @@ class _InteractiveArgsView(QtWidgets.QStackedWidget):
         assert first == last
         self.setCurrentIndex(0)
         self._insert_widget(first)
+        self.alert.emit()
 
     def rowsRemoved(self, parent, first, last):
         assert first == last
@@ -119,20 +121,34 @@ class _InteractiveArgsView(QtWidgets.QStackedWidget):
         widget.deleteLater()
         if self.tabs.count() == 0:
             self.setCurrentIndex(1)
+        self.alert.emit()
 
 
 class InteractiveArgsDock(QtWidgets.QDockWidget):
-    def __init__(self, interactive_args_sub, interactive_args_rpc):
+    def __init__(self, interactive_args_sub, interactive_args_rpc, main_window):
         QtWidgets.QDockWidget.__init__(self, "Interactive Args")
         self.setObjectName("Interactive Args")
         self.setFeatures(
             QtWidgets.QDockWidget.DockWidgetMovable | QtWidgets.QDockWidget.DockWidgetFloatable)
         self.interactive_args_rpc = interactive_args_rpc
+        self.main_window = main_window
         self.request_view = _InteractiveArgsView()
         self.request_view.supplied.connect(self.supply)
         self.request_view.cancelled.connect(self.cancel)
+        self.request_view.alert.connect(self._set_alert)
         self.setWidget(self.request_view)
         interactive_args_sub.add_setmodel_callback(self.request_view.setModel)
+
+    def _set_alert(self):
+        tabbar = self._find_tab_bar()
+        if tabbar is None:
+            return
+        tabbar_idx = self._tab_index(tabbar)
+        if tabbar_idx != tabbar.currentIndex():
+            self.setWindowTitle("(!)Interactive Args")
+
+    def _clear_alert(self):
+        self.setWindowTitle("Interactive Args")
 
     def supply(self, rid, values):
         asyncio.ensure_future(self._supply_task(rid, values))
@@ -153,3 +169,38 @@ class InteractiveArgsDock(QtWidgets.QDockWidget):
         except Exception:
             logger.error("failed to cancel interactive args request for experiment: %d",
                          rid, exc_info=True)
+
+    def showEvent(self, event):
+        super().showEvent(event)
+        QtCore.QTimer.singleShot(0, self._connect_to_tab_bar)
+
+    def _tab_index(self, tabbar):
+        # Return the index of this dock widget's tab in the given QTabBar.
+        for i in range(tabbar.count()):
+            if tabbar.tabText(i) == self.windowTitle():
+                return i
+        return None
+
+    def _on_tab_changed(self, index):
+        tabbar = self._find_tab_bar()
+        if tabbar is None:
+            return
+        my_index = self._tab_index(tabbar)
+        if my_index is not None and my_index == index:
+            self._clear_alert()
+
+    def _connect_to_tab_bar(self):
+        # Locate the QTabBar in the main window and connect its currentChanged
+        # signal so that when this tab is selected the alert is cleared.
+        tabbar = self._find_tab_bar()
+        if tabbar is not None:
+            tabbar.currentChanged.connect(self._on_tab_changed)
+
+    def _find_tab_bar(self):
+        # Search for a QTabBar among main_window’s children.
+        tabbars = self.main_window.findChildren(QtWidgets.QTabBar)
+        for tabbar in tabbars:
+            for i in range(tabbar.count()):
+                if tabbar.tabText(i) == self.windowTitle():
+                    return tabbar
+        return None

--- a/artiq/frontend/artiq_dashboard.py
+++ b/artiq/frontend/artiq_dashboard.py
@@ -393,7 +393,8 @@ def main():
 
     d_interactive_args = interactive_args.InteractiveArgsDock(
         sub_clients["interactive_args"],
-        rpc_clients["interactive_arg_db"]
+        rpc_clients["interactive_arg_db"],
+        main_window
     )
 
     d_schedule = schedule.ScheduleDock(


### PR DESCRIPTION
Solution is similar to changing the color of alerts tab (https://github.com/elhep/artiq/issues/6).

I tried again, but I was not able to make the styles work properly.

In the case of alerts colors, I created QLabel widget as a workaround.

Repeating the same here would be problematic, because for that approach I needed to change the tab-title to "". 
I cannot do the same here, because I would not be able to differentiate between the tabs.

Instead, to inform a user about new interactive arg, I add an explanation mark.